### PR TITLE
Customer dashborad show error() fix

### DIFF
--- a/lib/customer_dashboard.dart
+++ b/lib/customer_dashboard.dart
@@ -226,12 +226,16 @@ class _HomePageState extends State<HomePage> {
     } catch (e) {
       print('Error deleting request: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Error deleting request: $e'),
-          backgroundColor: Colors.red,
-        ),
-      );
+
+      Future.microtask(() {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error deleting request: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      });
     }
   }
 

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -395,55 +395,57 @@ class _LoginScreenState extends State<LoginScreen>
                                   ),
                                 ),
                                 const SizedBox(height: 10),
-                                GestureDetector(
-                                  onTap: _login,
-                                  child: AnimatedContainer(
-                                    width: 260,
-                                    padding: const EdgeInsets.symmetric(
-                                      vertical: 9,
-                                    ),
-                                    duration: Duration(
-                                      milliseconds: 150,
-                                    ), // Smooth scaling animation
-                                    decoration: BoxDecoration(
-                                      gradient: const LinearGradient(
-                                        colors: [
-                                          Color(0xFF4CAF50),
-                                          Color(0xFF66BB6A),
+                                Center(
+                                  child: GestureDetector(
+                                    onTap: _login,
+                                    child: AnimatedContainer(
+                                      width: 260,
+                                      padding: const EdgeInsets.symmetric(
+                                        vertical: 9,
+                                      ),
+                                      duration: Duration(
+                                        milliseconds: 150,
+                                      ), // Smooth scaling animation
+                                      decoration: BoxDecoration(
+                                        gradient: const LinearGradient(
+                                          colors: [
+                                            Color(0xFF4CAF50),
+                                            Color(0xFF66BB6A),
+                                          ],
+                                        ),
+                                        borderRadius: BorderRadius.circular(15),
+                                        boxShadow: [
+                                          BoxShadow(
+                                            color: Colors.green.withAlpha(
+                                              (0.5 * 255).toInt(),
+                                            ),
+                                            blurRadius: 10,
+                                            spreadRadius: 5,
+                                            offset: Offset(
+                                              0,
+                                              4,
+                                            ), // Shadow position for 3D effect
+                                          ),
                                         ],
                                       ),
-                                      borderRadius: BorderRadius.circular(15),
-                                      boxShadow: [
-                                        BoxShadow(
-                                          color: Colors.green.withAlpha(
-                                            (0.5 * 255).toInt(),
-                                          ),
-                                          blurRadius: 10,
-                                          spreadRadius: 5,
-                                          offset: Offset(
-                                            0,
-                                            4,
-                                          ), // Shadow position for 3D effect
-                                        ),
-                                      ],
-                                    ),
-                                    child: Center(
-                                      child:
-                                          _isLoading
-                                              ? CircularProgressIndicator(
-                                                valueColor:
-                                                    AlwaysStoppedAnimation<
-                                                      Color
-                                                    >(Colors.white),
-                                              )
-                                              : Text(
-                                                'Login',
-                                                style: TextStyle(
-                                                  color: Colors.white,
-                                                  fontSize: 18,
-                                                  fontWeight: FontWeight.w600,
+                                      child: Center(
+                                        child:
+                                            _isLoading
+                                                ? CircularProgressIndicator(
+                                                  valueColor:
+                                                      AlwaysStoppedAnimation<
+                                                        Color
+                                                      >(Colors.white),
+                                                )
+                                                : Text(
+                                                  'Login',
+                                                  style: TextStyle(
+                                                    color: Colors.white,
+                                                    fontSize: 18,
+                                                    fontWeight: FontWeight.w600,
+                                                  ),
                                                 ),
-                                              ),
+                                      ),
                                     ),
                                   ),
                                 ),


### PR DESCRIPTION
# 🛠 Fix: Prevent `ScaffoldMessenger` from Accessing a Deactivated Widget

## 📌 Issue Description
This pull request addresses a **FlutterError** that occurs when trying to access `ScaffoldMessenger.of(context)` on a deactivated widget. The error message:


---

## 🐛 **Root Cause**
- The widget was already unmounted when attempting to show a `SnackBar` in the `catch` block.
- `ScaffoldMessenger.of(context)` depends on `context`, which becomes invalid if the widget is disposed.

---

## ✅ **Changes Implemented**
### 1️⃣ **Added `Future.microtask()` to Delay `ScaffoldMessenger` Call**
- Ensures that `ScaffoldMessenger.of(context)` executes in the next event loop.
- Prevents accessing an unmounted widget.

#### 🔹 **Code Before Fix**
```dart
} catch (e) {
  print('Error deleting request: $e');
  if (!mounted) return;

  ScaffoldMessenger.of(context).showSnackBar(
    SnackBar(
      content: Text('Error deleting request: $e'),
      backgroundColor: Colors.red,
    ),
  );
}

